### PR TITLE
feat: ID Search / PW change

### DIFF
--- a/src/main/kotlin/refresh/onecake/member/adapter/infra/api/LoginController.kt
+++ b/src/main/kotlin/refresh/onecake/member/adapter/infra/api/LoginController.kt
@@ -52,4 +52,22 @@ class LoginController (
     fun logout(): ResponseEntity<DefaultResponseDto> {
         return ApiResponse.success(HttpStatus.OK, loginService.logout())
     }
+
+    @Operation(summary = "ID찾기")
+    @PostMapping("/id")
+    fun searchUserID(@RequestBody idPwSearchRequestDto: UserIdSearchRequestDto): ResponseEntity<UserIdSearchResponseDto> {
+        return ApiResponse.success(
+                HttpStatus.OK,
+                loginService.searchUserId(idPwSearchRequestDto)
+        )
+    }
+
+    @Operation(summary = "PW수정")
+    @PostMapping("/password")
+    fun changePassword(@RequestBody passwordChangeRequestDto: PasswordChangeRequestDto): ResponseEntity<DefaultResponseDto> {
+        return ApiResponse.success(
+                HttpStatus.OK,
+                loginService.changePassword(passwordChangeRequestDto)
+        )
+    }
 }

--- a/src/main/kotlin/refresh/onecake/member/adapter/infra/dto/PasswordChangeRequestDto.kt
+++ b/src/main/kotlin/refresh/onecake/member/adapter/infra/dto/PasswordChangeRequestDto.kt
@@ -1,0 +1,11 @@
+package refresh.onecake.member.adapter.infra.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy::class)
+data class PasswordChangeRequestDto(
+
+    val userId: String,
+    val password: String
+)

--- a/src/main/kotlin/refresh/onecake/member/adapter/infra/dto/UserIdSearchRequestDto.kt
+++ b/src/main/kotlin/refresh/onecake/member/adapter/infra/dto/UserIdSearchRequestDto.kt
@@ -1,0 +1,10 @@
+package refresh.onecake.member.adapter.infra.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy::class)
+data class UserIdSearchRequestDto(
+
+    val phoneNumber: String
+)

--- a/src/main/kotlin/refresh/onecake/member/adapter/infra/dto/UserIdSearchResponseDto.kt
+++ b/src/main/kotlin/refresh/onecake/member/adapter/infra/dto/UserIdSearchResponseDto.kt
@@ -1,0 +1,10 @@
+package refresh.onecake.member.adapter.infra.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy::class)
+data class  UserIdSearchResponseDto(
+
+    val userId: String
+)

--- a/src/main/kotlin/refresh/onecake/member/application/LoginService.kt
+++ b/src/main/kotlin/refresh/onecake/member/application/LoginService.kt
@@ -1,5 +1,6 @@
 package refresh.onecake.member.application
 
+import org.springframework.dao.EmptyResultDataAccessException
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
@@ -156,5 +157,58 @@ class LoginService(
         redisTemplate.opsForValue().set("RT:$id", "", 1, TimeUnit.MILLISECONDS)
         redisTemplate.opsForValue().set(memberRepository.findMemberById(id).userId, "", 1, TimeUnit.MILLISECONDS)
         return DefaultResponseDto(true, "로그아웃 되었습니다.")
+    }
+
+    /**
+     * 연락처로 userId 검색하는 Function
+     * @author 메이슨
+     * @param idSearchRequestDto phoneNumber
+     * @return userId
+     * @exception ForbiddenException 해당 연락처가 존재하지 않는 경우 / 탈퇴한 회원일 경우
+     */
+    @Transactional
+    fun searchUserId(idSearchRequestDto: UserIdSearchRequestDto): UserIdSearchResponseDto {
+
+        val member: Member;
+
+        try {
+            member = memberRepository.findByPhoneNumber(idSearchRequestDto.phoneNumber);
+        } catch (e: EmptyResultDataAccessException) {
+            throw ForbiddenException("회원이 존재하지 않습니다")
+        }
+
+        if (!member.isActivated) {
+            throw ForbiddenException("탈퇴한 회원입니다.")
+        }
+
+        return UserIdSearchResponseDto(member.userId)
+    }
+
+    /**
+     * userId로 password를 재설정하는 Function
+     * @author 메이슨
+     * @param PasswordChangeRequestDto userId, 재설정할 password
+     * @exception ForbiddenException 해당 회원이 존재하지 않는 경우 / 탈퇴한 회원일 경우 / 재설정할 암호가 비어있는 경우
+     */
+    @Transactional
+    fun changePassword(passwordChangeRequestDto: PasswordChangeRequestDto): DefaultResponseDto {
+        val member: Member;
+
+        try {
+            member = memberRepository.getByUserId(passwordChangeRequestDto.userId);
+        } catch (e: EmptyResultDataAccessException) {
+            throw ForbiddenException("회원이 존재하지 않습니다")
+        }
+        if (!member.isActivated) {
+            throw ForbiddenException("탈퇴한 회원입니다.")
+        }
+        if (passwordChangeRequestDto.password.isBlank()) {
+            throw ForbiddenException("암호가 비어있습니다")
+        }
+
+        member.password = passwordEncoder.encode(passwordChangeRequestDto.password)
+        memberRepository.save(member)
+
+        return DefaultResponseDto(true, "암호 수정이 완료됐습니다.")
     }
 }

--- a/src/main/kotlin/refresh/onecake/member/domain/MemberRepository.kt
+++ b/src/main/kotlin/refresh/onecake/member/domain/MemberRepository.kt
@@ -10,4 +10,5 @@ interface MemberRepository: JpaRepository<Member, Long> {
     fun getByUserId(userId:String): Member
     fun existsByUserId(userId:String) : Boolean
     fun findMemberTypeById(id:Long) : MemberType
+    fun findByPhoneNumber(phoneNumber:String): Member
 }


### PR DESCRIPTION
# Feat
- 연락처로 userId를 찾는 API가 추가되었습니다
    - `/api/v1/auth/id` (POST)
- userId로 password를 재설정하는 API가 추가되었습니다
    - `/api/v1/auth/password` (POST)

# New file
- src/main/kotlin/refresh/onecake/member/adapter/infra/dto/
    - [UserIdSearchRequestDto.kt](https://github.com/Refresh-Onecake/Onecake_BackEnd/compare/Mason-ID/PW-find...mskim9967:Mason-ID/PW-find?expand=1#diff-03e559fc8e0b059bc25d45d36bdf33e47262d0057fe9f952e6de6197003350cd) : userId 찾기 Request Dto
    - [UserIdSearchResponseDto.kt](https://github.com/Refresh-Onecake/Onecake_BackEnd/compare/Mason-ID/PW-find...mskim9967:Mason-ID/PW-find?expand=1#diff-cfa4b4db8527558d761f532265386cbe982b70e3f923d3d81de4cf7e2215cf6c) userId 찾기 Response Dto
    - [PasswordChangeRequestDto.kt](https://github.com/Refresh-Onecake/Onecake_BackEnd/compare/Mason-ID/PW-find...mskim9967:Mason-ID/PW-find?expand=1#diff-46fbe2318fa587d2d26e32f9869693e40c9c2ebaba982c482d36e9eb16108056) : 암호 변경 Request Dto

# Modified file
- [src/main/kotlin/refresh/onecake/member/domain/MemberRepository.kt](https://github.com/Refresh-Onecake/Onecake_BackEnd/compare/Mason-ID/PW-find...mskim9967:Mason-ID/PW-find?expand=1#diff-399ba9b2a485292a7ebb3600ae7fda988c779f9321e409246b64bf6625bbd8ec)
    - 연락처로 ID를 찾기 위한 function 추가
- [src/main/kotlin/refresh/onecake/member/application/LoginService.kt](https://github.com/Refresh-Onecake/Onecake_BackEnd/compare/Mason-ID/PW-find...mskim9967:Mason-ID/PW-find?expand=1#diff-2eeef416d372777b0a4b7fc9891df1761fbffe47bdbdf17b9187789947da9735)
    - Service Logic 추가
- [src/main/kotlin/refresh/onecake/member/adapter/infra/api/LoginController.kt](https://github.com/Refresh-Onecake/Onecake_BackEnd/compare/Mason-ID/PW-find...mskim9967:Mason-ID/PW-find?expand=1#diff-100ec0330db73741e8f12bcc16fd2f9728deba211a648ed4254f10f09abab3dd)
    - API Controller 추가

# Issue
- [fcm private key](https://github.com/Refresh-Onecake/Onecake_BackEnd/blob/30278630e572f2ac9bf36518ccb41df3e76cd38f/src/main/resources/onecake-fcm.json)는 노출되면 안되는 것으로 알고 있습니다..! git에서 지우고 키를 재발급 받아야 할 것 같습니다
- 위 방법으로 ID검색/PW재설정 시 Identification 과정이 존재하지 않아 보안 상 위험해보입니다. 휴대폰 인증을 Client에서 처리하기 때문에 일단은 이렇게 작성하였는데, 휴대폰 인증 이후 이 요청이 유효한 요청인지 확인하는 과정이 필요해 보입니다